### PR TITLE
made changes to follow default starting rules, which avoid 6 8 collision

### DIFF
--- a/lib/src/base_model/constants.dart
+++ b/lib/src/base_model/constants.dart
@@ -9,6 +9,11 @@ List<int> defaultCoordinateKeys = [
   3843, 3738, 3740, 3742
 ];
 
+List<int> standardDealKeys = [
+  3742, 3740, 3738, 3837, 4036, 4137, 4338, 4340, 4342, 4143,
+  4044, 3843, 3841, 3839, 4038, 4139, 4141, 4042, 4040
+];
+
 List<TerrainType> defaultTiles = [
   TerrainType.Desert,
   TerrainType.Pasture, TerrainType.Pasture, TerrainType.Pasture, TerrainType.Pasture,
@@ -29,6 +34,11 @@ List<int> defaultTokens = [
   10, 10,
   11, 11,
   12,
+];
+
+List<int> standardOrderTokens = [
+  5, 2, 6, 3, 8, 10, 9, 12, 11, 4, 8,
+  10, 9, 4, 5, 6, 3, 11,
 ];
 
 List<int> chanceList = [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1];

--- a/lib/src/game_module/store.dart
+++ b/lib/src/game_module/store.dart
@@ -60,14 +60,14 @@ class GameStore extends Store {
   }
 
   _newBoard() {
-    if (defaultCoordinateKeys.length != 19) print('WARNING!!! Incorrect Default Coordinate Count ${defaultCoordinateKeys.length}');
+    if (standardDealKeys.length != 19) print('WARNING!!! Incorrect Default Coordinate Count ${defaultCoordinateKeys.length}');
     if (defaultTiles.length != 19) print('WARNING!!! Incorrect Default Tile Count ${defaultTiles.length}');
     if (defaultTokens.length != 18) print('WARNING!!! Incorrect Default Tile Count ${defaultTokens.length}');
 
     List<TerrainType> types = new List<TerrainType>.from(defaultTiles)..shuffle();
-    List<int> tokens = new List<int>.from(defaultTokens)..shuffle();
+    List<int> tokens = new List<int>.from(standardOrderTokens);
 
-    defaultCoordinateKeys.forEach((key) {
+    standardDealKeys.forEach((key) {
       Coordinate coordinate = new Coordinate.fromKey(key);
       Terrain terrain = new Terrain(coordinate);
       gameBoard.map[key] = terrain;


### PR DESCRIPTION
The existing code could easily produce illegal starting positions per the[ default Catan rules](http://www.catan.com/service/game-rules). 

To fix this, I included standard default board dealing orders and tile orders.  
